### PR TITLE
Fix productsPerRow select reset to 1

### DIFF
--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -66,6 +66,7 @@
             <div class="form-group">
 			    <label>Products per row</label>
                 <select class="form-control" name="productsPerRow">
+                    <option value="{{config.productsPerRow}}" hidden="hidden" selected="selected">{{config.productsPerRow}}</option>
                     <option {{selectState '1' config.productsPerRow}}>1</option>
                     <option {{selectState '2' config.productsPerRow}}>2</option>
                     <option {{selectState '3' config.productsPerRow}}>3</option>


### PR DESCRIPTION
When settings page are loaded, select doesn't reflect value of
config.productsPerRow and resets to 1. Following settings update
saves that value.