### PR TITLE
Fix bugs in Stripe and crashes in Paypal modules

### DIFF
--- a/routes/payments/paypal.js
+++ b/routes/payments/paypal.js
@@ -12,7 +12,7 @@ router.get('/checkout_return', (req, res, next) => {
     let db = req.app.db;
     let config = common.getConfig();
     let paymentId = req.session.paymentId;
-    let payerId = req.param('PayerID');
+    let payerId = req.query['PayerID'];
 
     let details = {'payer_id': payerId};
     paypal.payment.execute(paymentId, details, (error, payment) => {
@@ -190,10 +190,7 @@ router.post('/checkout_action', (req, res, next) => {
                     }
 
                     // get the new ID
-                    let newId = '';
-                    if(newDoc.insertedIds.length > 0){
-                        newId = newDoc.insertedIds[0].toString();
-                    }
+                    let newId = newDoc.insertedIds['0'];
 
                     // set the order ID in the session
                     req.session.orderId = newId;

--- a/routes/payments/stripe.js
+++ b/routes/payments/stripe.js
@@ -60,7 +60,7 @@ router.post('/checkout_action', (req, res, next) => {
             }
 
             // get the new ID
-            let newId = newDoc.insertedIds;
+            let newId = newDoc.insertedIds['0'];
 
             // add to lunr index
             common.indexOrders(req.app)
@@ -70,7 +70,7 @@ router.post('/checkout_action', (req, res, next) => {
                     // set the results
                     req.session.messageType = 'success';
                     req.session.message = 'Your payment was successfully completed';
-                    req.session.paymentEmailAddr = newDoc.orderEmail;
+                    req.session.paymentEmailAddr = newDoc.ops[0].orderEmail;
                     req.session.paymentApproved = true;
                     req.session.paymentDetails = '<p><strong>Order ID: </strong>' + newId + '</p><p><strong>Transaction ID: </strong>' + charge.id + '</p>';
 


### PR DESCRIPTION
- Paypal: deprecated `req.param` in express
- Paypal: `newId` was saving in DB as empty string
- Stripe: `newId` was undefined, resulting in wrongly reported unsuccesful
transaction
- Stripe: client email was not sending because was undefined

Those TODOs was about that?