### PR TITLE
Fix order options

### DIFF
--- a/routes/order.js
+++ b/routes/order.js
@@ -61,14 +61,10 @@ router.get('/admin/order/view/:id', common.restrict, (req, res) => {
         if(err){
             console.info(err.stack);
         }
-        let productOptions = '';
-        if(result.options !== {}){
-            productOptions = result.options;
-        }
+        
         res.render('order', {
             title: 'View order',
             result: result,
-            productOptions: productOptions,
             config: req.app.config,
             session: req.session,
             message: common.clearSessionValue(req.session, 'message'),

--- a/views/order.hbs
+++ b/views/order.hbs
@@ -44,11 +44,11 @@
             {{#each result.orderProducts}}
                 <li class="list-group-item">
                     {{this.quantity}} x {{this.title}}
-                    {{#if productOptions}}
+                    {{#if this.options}}
                         &nbsp; > &nbsp;
                         <span class="text-warning"> Options: </span>
                         (
-                        {{#each productOptions}}
+                        {{#each this.options}}
                             {{#if @last}}
                                 {{this}}
                             {{else}}


### PR DESCRIPTION
The /admin/order/view/:id route in routes/order.js tries to build orderOptions for the view but the var is an array and needs to be inspected for each ordered item.  I removed the code from the route and updated the #each loop in the views/order.hbs view to allow display of the order options in the admin panel.