### PR TITLE
check for admin view before loading materialize js

### DIFF
--- a/views/layouts/layout.hbs
+++ b/views/layouts/layout.hbs
@@ -39,7 +39,9 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.9/validator.min.js"></script>
         <script src="/javascripts/jquery.bootpag.min.js"></script>
         <script src="/javascripts/cssbeautify.min.js"></script>
+        {{#unless admin}}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
+        {{/unless}}
 		<script src="/javascripts/expressCart{{config.env}}.js"></script>
         <script src="/javascripts/jquery.dotdotdot.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-tokenfield/0.12.0/bootstrap-tokenfield.min.js"></script>


### PR DESCRIPTION
I was getting a console error when trying to use the Summernote link and image buttons:

Error: Method show does not exist on jQuery.modal

After researching a bit I found a post that indicates it might be a conflict with the materialize js.  When I comment the materialize js out in the admin view the Summernote link and image modals begin to work.  Not sure if the materialize js is needed elsewhere in the admin view but I added a check in the layout file to not load it if we're in the admin panel.