### PR TITLE
Fix missing python dependency in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM mhart/alpine-node:8
 
 ENV NODE_VERSION 8.9.4
 
+RUN apk add --no-cache make gcc g++ python bash
+
 WORKDIR /var/expressCart
 
+COPY lib/ /var/expressCart/lib/
 COPY bin/ /var/expressCart/bin/
 COPY config/ /var/expressCart/config/
 COPY public/ /var/expressCart/public/


### PR DESCRIPTION
Prior to this change, running `docker-compose up` complains that python can't be found during `npm install`.

Also fixes the error about the missing `common` directory.