### PR TITLE
Handle settings changes without restart

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,6 +249,15 @@ app.use((req, res, next) => {
     next();
 });
 
+// update config when modified
+app.use((req, res, next) => {
+    next();
+    if (res.configDirty) {
+        config = common.getConfig();
+        app.config = config;
+    }
+});
+
 // Ran on all routes
 app.use((req, res, next) => {
     res.setHeader('Cache-Control', 'no-cache, no-store');

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -171,6 +171,7 @@ router.post('/admin/settings/update', common.restrict, common.checkAccess, (req,
     let result = common.updateConfig(req.body);
     if(result === true){
         res.status(200).json({message: 'Settings successfully updated'});
+        res.configDirty = true;
         return;
     }
     res.status(400).json({message: 'Permission denied'});


### PR DESCRIPTION
Prior to this change, edited settings on the /admin/settings page
required a restart for the edit to take effect. This even causes the
settings page itself to not reflect the updated settings once you
navigate away from it or refresh. This change triggers the config to
reload when the settings are modified, which causes the impacted
templates to be recomputed.