### PR TITLE
Allow for an ignored local settings file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 data/
-config/settings.json
+/config/settings-local.json
 .vscode
 **.DS_Store

--- a/README.md
+++ b/README.md
@@ -122,7 +122,13 @@ Note: The `databaseConnectionString` property requires a full connection string.
 
 ## Configuration
 
-All settings are managed from the admin panel ([http://127.0.0.1:1111/admin](http://127.0.0.1:1111/admin)) except the Payment gateway and database settings.
+Settings can be managed from the admin panel ([http://127.0.0.1:1111/admin](http://127.0.0.1:1111/admin)) with the exception of the Payment gateway and database settings.
+
+All settings are stored in json files in the `/config` directory. The main application-level settings are stored in `/config/settings.json` while payment gateway settings are stored in files in the `/config` directory named after the payment gateway. For example, configuration for the Stripe payment gateway is stored in `/config/stripe.json`.
+
+##### Local configuration
+
+If you'd rather store settings in a file which isn't checked into version control, you can create a new settings file at `/config/settings-local.json` and store your complete settings there. When viewing or editing settings in the admin panel, expressCart will detect the existence of this file and update it accordingly.
 
 ##### Cart name and Cart description
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -210,8 +210,17 @@ exports.getImages = (dir, req, res, callback) => {
     });
 };
 
+exports.getConfigFilename = () => {
+    let filename = path.join(__dirname, '../config', 'settings-local.json');
+    if (fs.existsSync(filename)) {
+      return filename;
+    } else {
+      return path.join(__dirname, '../config', 'settings.json');
+    }
+};
+
 exports.getConfig = () => {
-    let config = JSON.parse(fs.readFileSync(path.join(__dirname, '../config', 'settings.json'), 'utf8'));
+    let config = JSON.parse(fs.readFileSync(exports.getConfigFilename(), 'utf8'));
     config.customCss = typeof config.customCss !== 'undefined' ? escape.decode(config.customCss) : null;
     config.footerHtml = typeof config.footerHtml !== 'undefined' ? escape.decode(config.footerHtml) : null;
     config.googleAnalytics = typeof config.googleAnalytics !== 'undefined' ? escape.decode(config.googleAnalytics) : null;
@@ -248,7 +257,7 @@ exports.getPaymentConfig = () => {
 };
 
 exports.updateConfig = (fields) => {
-    let settingsFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../config/settings.json'), 'utf8'));
+    let settingsFile = exports.getConfig();
 
     _.forEach(fields, (value, key) => {
         settingsFile[key] = value;
@@ -304,7 +313,7 @@ exports.updateConfig = (fields) => {
 
     // write file
     try{
-        fs.writeFileSync(path.join(__dirname, '../config/settings.json'), JSON.stringify(settingsFile, null, 4));
+        fs.writeFileSync(exports.getConfigFilename(), JSON.stringify(settingsFile, null, 4));
         return true;
     }catch(exception){
         return false;


### PR DESCRIPTION
Even though `settings.json` is in the `.gitignore` file, git does not ignore
modifications to this file. This change makes expressCart detect the
existence of a file called `settings-local.json`. When this file exists,
it will be used for reading and writing settings instead of the usual
`settings.json`. This will help to prevent accidental leakage of user
secrets.