### PR TITLE
Rename mongodb container to expresscart-mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       - mongodb
   mongodb:
     image: mongo:3.4.10
-    container_name: "mongodb"
+    container_name: "expresscart-mongodb"
     ports:
       - 27017
     volumes:
-      - mongo-data:/data/db
+      - expresscart-mongo-data:/data/db
     ports:
       - 27017:27017
     command: mongod --smallfiles --logpath=/dev/null
 volumes:
-  mongo-data:
+  expresscart-mongo-data:


### PR DESCRIPTION
Also renames the mongodb volume to `expresscart-mongo-data`. This change avoids naming conflicts with other mongodb containers.