### PR TITLE
minor fix for image upload issue if multiple sub dir to be created

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -10,6 +10,7 @@ const async = require('async');
 const nodemailer = require('nodemailer');
 const sanitizeHtml = require('sanitize-html');
 const escape = require('html-entities').AllHtmlEntities;
+const mkdirp = require('mkdirp');
 let ObjectId = require('mongodb').ObjectID;
 
 const restrictedRoutes = [
@@ -177,7 +178,12 @@ exports.checkDirectorySync = (directory) => {
     try{
         fs.statSync(directory);
     }catch(e){
+        try{
         fs.mkdirSync(directory);
+        }
+        catch(err){
+           mkdirp.sync(directory);//error : directory & sub directories to be newly created
+        }
     }
 };
 


### PR DESCRIPTION
This solves issue occured while adding a PermaLink which contains url (ex: main-product/sub-product)
where in 2 of the folders needs to be created in uploads directory but system fails now as in common.js file fs.mkdirSync() is used for single directory creation .i have added mkdirp to add recurisive sub directories if required inside common.js file.