### PR TITLE
Keep old images when changing permalink - correct productPublished field

### DIFF
--- a/app.js
+++ b/app.js
@@ -190,7 +190,7 @@ handlebars = handlebars.create({
         formatDate: (date, format) => {
             return moment(date).format(format);
         },
-        ifCond: (v1, operator, v2, options) => {
+        ifCond: function (v1, operator, v2, options) {
             switch(operator){
             case'==':
                 return(v1 === v2) ? options.fn(this) : options.inverse(this);

--- a/lib/common.js
+++ b/lib/common.js
@@ -496,7 +496,7 @@ const getData = (req, page, query) => {
         query = {};
     }
 
-    query['productPublished'] = 'true';
+    query['productPublished'] = true;
 
     // Run our queries
     return Promise.all([

--- a/routes/product.js
+++ b/routes/product.js
@@ -429,7 +429,7 @@ router.get('/admin/product/delete/:id', restrict, checkAccess, (req, res) => {
 router.post('/admin/product/published_state', restrict, checkAccess, (req, res) => {
     const db = req.app.db;
 
-    db.products.update({ _id: common.getId(req.body.id) }, { $set: { productPublished: req.body.state } }, { multi: false }, (err, numReplaced) => {
+    db.products.update({ _id: common.getId(req.body.id) }, { $set: { productPublished: common.convertBool(req.body.state) } }, { multi: false }, (err, numReplaced) => {
         if(err){
             console.error(colors.red('Failed to update the published state: ' + err));
             res.status(400).json('Published state not updated');

--- a/routes/product.js
+++ b/routes/product.js
@@ -353,22 +353,16 @@ router.post('/admin/product/update', restrict, checkAccess, (req, res) => {
                     // Remove productId from doc
                     delete productDoc.productId;
 
-                    // if no featured image
-                    if(!product.productImage){
-                        if(images.length > 0){
-                            productDoc['productImage'] = images[0].path;
-                        }else{
-                            productDoc['productImage'] = '/uploads/placeholder.png';
-                        }
-                    }else{
-                        productDoc['productImage'] = product.productImage;
-                    }
-
                     // rename upload images directory when changing permalink
                     if (product.productPermalink !== productDoc.productPermalink) {
                         const oldUploadImagesDir = path.join(__dirname, '../public/uploads', product.productPermalink);
                         const newUploadImagesDir = path.join(__dirname, '../public/uploads', productDoc.productPermalink);
                         fs.renameSync(oldUploadImagesDir, newUploadImagesDir);
+
+                        // if no featured image
+                        if(!product.productImage) {
+                            productDoc['productImage'] = newUploadImagesDir + product.productImage.split('/').pop();
+                        }
                     }
 
                     db.products.update({ _id: common.getId(req.body.productId) }, { $set: productDoc }, {}, (err, numReplaced) => {

--- a/routes/product.js
+++ b/routes/product.js
@@ -364,6 +364,13 @@ router.post('/admin/product/update', restrict, checkAccess, (req, res) => {
                         productDoc['productImage'] = product.productImage;
                     }
 
+                    // rename upload images directory when changing permalink
+                    if (product.productPermalink !== productDoc.productPermalink) {
+                        const oldUploadImagesDir = path.join(__dirname, '../public/uploads', product.productPermalink);
+                        const newUploadImagesDir = path.join(__dirname, '../public/uploads', productDoc.productPermalink);
+                        fs.renameSync(oldUploadImagesDir, newUploadImagesDir);
+                    }
+
                     db.products.update({ _id: common.getId(req.body.productId) }, { $set: productDoc }, {}, (err, numReplaced) => {
                         if(err){
                             // If API request, return json

--- a/views/product_edit.hbs
+++ b/views/product_edit.hbs
@@ -1,6 +1,7 @@
 {{> partials/menu}}
 <div class="col-lg-9">
     <form method="post" class="form-horizontal" id="insert_form" action="/admin/product/update" data-toggle="validator">
+        <input type="hidden" value="{{result._id}}" id="frmProductId">
         <div class="col-lg-12">
             <div class="page-header">
                 <div class="pull-right">


### PR DESCRIPTION
- Keep old images when changing permalink.
- Use convertBool when update "productPublished"
- Missing tag "frmProductId" --> bug when calling $('#frmProductId').val()