### PR TITLE
pm2 name command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Discount code:
 Keeping expressCart running after closing the terminal can be done in a few ways but we recommend using the `PM2` package. To set this up:
 
 1. Install PM2: `npm install pm2 -g`
-2. Add expressCart to PM2: `NODE_ENV=production pm2 start app.js --name "expressCart"`
+2. Add expressCart to PM2: `NODE_ENV=production pm2 start app.js --name expressCart`
 3. Check PM2 has our app: `pm2 list`
 4. Save the PM2 config: `pm2 save`
 5. To start/stop: `pm2 start expressCart` / `pm2 stop expressCart`


### PR DESCRIPTION
Removed double quotes as the name command in pm2 does not accept a string argument.
refer: https://pm2.keymetrics.io/docs/usage/pm2-doc-single-page/