### PR TITLE
Fix `-` in product name breaks product view

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -405,9 +405,14 @@ router.get('/product/:id', async (req, res) => {
         const productTitleWords = product.productTitle.split(' ');
         const searchWords = productTags.concat(productTitleWords);
         searchWords.forEach((word) => {
-            productsIndex.search(word).forEach((id) => {
-                lunrIdArray.push(getId(id.ref));
-            });
+            try {
+                results = productsIndex.search(word)
+                results.forEach((id) => {
+                    lunrIdArray.push(getId(id.ref));
+                });
+            } catch (e) {
+                console.log('lunr search query error')
+            }
         });
         relatedProducts = await db.products.find({
             _id: { $in: lunrIdArray, $ne: product._id }


### PR DESCRIPTION
Generation of search words in order for querying for related will fail and timeout if the current product name includes a ' - ' (possibly other characters as well?). For example a product named `test item - 2020` will cause lunr to break. To replicate this change a product name to include ' - ' and load that products view - '/product/:id'

In order to resolve this I have wrapped the lunr search inside a try catch which has solved the issue for my expresscart installation.