### PR TITLE
Fix webhooks sending multiple times for a single order

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -104,10 +104,18 @@ router.get('/payment/:orderId', async (req, res, next) => {
         }
     }
 
-    // If hooks are configured, send hook
-    if(config.orderHook){
+    // If hooks are configured and the hook has not already been sent, send hook
+    if(config.orderHook && !order.hookSent){
         await hooker(order);
+        await db.orders.updateOne({
+            _id: getId(order._id)
+        }, {
+            $set: {
+                hookSent: true
+            }
+        }, { multi: false });
     };
+    
     let paymentView = `${config.themeViews}payment-complete`;
     if(order.orderPaymentGateway === 'Blockonomics') paymentView = `${config.themeViews}payment-complete-blockonomics`;
     res.render(paymentView, {


### PR DESCRIPTION
This pull request adds a boolean field to an order upon sending a webhook after an order is processed and user returns from the third party payment platform to solve #167 on page load this field is checked prior to calling the webhook function.

Feel free to add criticism or advice, happy to make some more changes if there is a better solution to this problem.