### PR TITLE
allow for RON currency

### DIFF
--- a/config/settingsSchema.json
+++ b/config/settingsSchema.json
@@ -65,7 +65,7 @@
         },
         "currencyISO": {
             "type": "string",
-            "enum": ["USD", "EUR", "GBP"],
+            "enum": ["USD", "EUR", "GBP", "RON"],
             "default": "USD"
         },
         "paymentGateway": {


### PR DESCRIPTION
allow RON (Romanian currency) to be used.

The used symbol of RON is "Lei" as the symbol "L" never gets used.
I checked in the storefront and admin panel. things work with "Lei" used as symbol